### PR TITLE
GDB-7072 Disable anonymous stats being sent

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -7,7 +7,7 @@
     <version>1.1-SNAPSHOT</version>
 
     <properties>
-        <graphdb.version>10.0.0-M2-TR13</graphdb.version>
+        <graphdb.version>10.0.0</graphdb.version>
         <dependency.check.version>6.2.2</dependency.check.version>
 
         <internal.repo>http://maven.ontotext.com/content/repositories/owlim-releases</internal.repo>
@@ -35,6 +35,16 @@
                 <configuration>
                     <source>1.8</source>
                     <target>1.8</target>
+                </configuration>
+            </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-surefire-plugin</artifactId>
+                <version>3.0.0-M3</version>
+                <configuration>
+                    <systemPropertyVariables>
+                        <graphdb.stats.default>disabled</graphdb.stats.default>
+                    </systemPropertyVariables>
                 </configuration>
             </plugin>
             <plugin>

--- a/src/test/java/com/ontotext/trree/plugin/sequences/TestSequencesPlugin.java
+++ b/src/test/java/com/ontotext/trree/plugin/sequences/TestSequencesPlugin.java
@@ -1,5 +1,7 @@
 package com.ontotext.trree.plugin.sequences;
 
+import com.ontotext.graphdb.Config;
+import com.ontotext.test.TemporaryLocalFolder;
 import com.ontotext.test.functional.base.SingleRepositoryFunctionalTest;
 import com.ontotext.test.utils.OwlimSeRepositoryDescription;
 import com.ontotext.trree.graphdb.GraphDBRepositoryFactory;
@@ -13,6 +15,9 @@ import org.eclipse.rdf4j.repository.config.RepositoryConfig;
 import org.eclipse.rdf4j.repository.sail.config.SailRepositoryConfig;
 import org.hamcrest.CoreMatchers;
 import org.hamcrest.MatcherAssert;
+import org.junit.AfterClass;
+import org.junit.BeforeClass;
+import org.junit.ClassRule;
 import org.junit.Test;
 
 import java.util.concurrent.ExecutionException;
@@ -28,6 +33,20 @@ import static org.junit.Assert.fail;
  * Tests for using the Sequences plugin
  */
 public class TestSequencesPlugin extends SingleRepositoryFunctionalTest {
+    @ClassRule
+    public static TemporaryLocalFolder tmpFolder = new TemporaryLocalFolder();
+
+    @BeforeClass
+    public static void setWorkDir() {
+        System.setProperty("graphdb.home.work", String.valueOf(tmpFolder.getRoot()));
+        Config.reset();
+    }
+
+    @AfterClass
+    public static void resetWorkDir() {
+        System.clearProperty("graphdb.home.work");
+        Config.reset();
+    }
     @Override
     protected RepositoryConfig createRepositoryConfiguration() {
         final OwlimSeRepositoryDescription repositoryDescription = new OwlimSeRepositoryDescription();


### PR DESCRIPTION
Change graphDB version to 10.0.0.
Add custom configuration for surefire plugin in pom.xml file, so we can add  
 "<graphdb.stats.default>disabled</graphdb.stats.default>".
Add temporary home.work folder to the TestSequencesPlugin.java.